### PR TITLE
Found the bug in line 44.

### DIFF
--- a/Project.js
+++ b/Project.js
@@ -41,7 +41,7 @@ function startAnalysis() {
             .catch(error => {
              console.error(error);
             }),
-            checkAndFixPythonIndentation('test.py')
+            checkAndFixPythonIndentation(fileName)
         ];
 
         // Wait for all operations to complete


### PR DESCRIPTION
Argument for ```checkAndFixPythonIndentation(fileName)``` was ```'test.py``` which is why it was allowing the tests to pass.
